### PR TITLE
added -w to "grep .rodata " for accurate search

### DIFF
--- a/firmware/fw_extractor
+++ b/firmware/fw_extractor
@@ -10,7 +10,7 @@ if len(sys.argv) != 2:
 
 filename = sys.argv[1]
 
-p = Popen(['/bin/sh', '-c', 'readelf -S '+ filename + ' | grep .rodata\ '], stdout=PIPE)
+p = Popen(['/bin/sh', '-c', 'readelf -S '+ filename + ' | grep -w .rodata\ '], stdout=PIPE)
 
 args = p.stdout.readlines()
 


### PR DESCRIPTION
if we have more than one string ".rodata" the condition "if len(args) != 1:" is triggered.
It's a false positive if we have simple .rodata section.
Example:
root@vbox-vm:/media/sf_sqfs# readelf -S gslX680.ko| grep  '.rodata\ '
  [31] .rodata           PROGBITS        00000000 001604 03d7bc 00   A  0   0  4
  [32] .rel.rodata       REL             00000000 05779c 000010 08     62  31  4

If we add '-w' to grep, we have:
root@vbox-vm:/media/sf_sqfs# readelf -S gslX680.ko| grep -w '.rodata\ '
  [31] .rodata           PROGBITS        00000000 001604 03d7bc 00   A  0   0  4

We can continue to extract the firmware.
