### PR TITLE
add the possibility to define specific firmware name

### DIFF
--- a/gslx680_ts_acpi.c
+++ b/gslx680_ts_acpi.c
@@ -17,6 +17,7 @@
  */
 
 #include <linux/module.h>
+#include <linux/moduleparam.h>
 #include <linux/input.h>
 #include <linux/interrupt.h>
 #include <linux/platform_device.h>
@@ -61,7 +62,6 @@
 	sizeof(struct gsl_ts_packet_header) \
 )
 
-#define GSL_FW_NAME "silead_ts.fw"
 #define GSL_FW_VERSION 1
 #define GSL_FW_ID_LIT(a, b, c, d) ( \
 	((a) & 0xff) | \
@@ -77,6 +77,10 @@
 	(m)%10+'0' \
 )
 #define GSL_FW_MODEL_1680 GSL_FW_MODEL_LIT(1680)
+
+/* Module Parameter (optional)*/
+static char *fw_name = "silead_ts.fw";
+module_param(fw_name, charp, 0000);
 
 /* Driver state */
 enum gsl_ts_state {
@@ -519,7 +523,7 @@ static int gsl_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 	ts->client = client;
 	i2c_set_clientdata(client, ts);
 	
-	error = request_firmware(&fw, GSL_FW_NAME, &ts->client->dev);
+	error = request_firmware(&fw, fw_name, &ts->client->dev);
 	if (error < 0) {
 		dev_err(&client->dev, "%s: failed to load firmware: %d\n", __func__, error);
 		goto release;
@@ -764,5 +768,6 @@ module_i2c_driver(gslx680_ts_driver);
 
 MODULE_DESCRIPTION("GSLX680 touchscreen controller driver");
 MODULE_AUTHOR("Gregor Riepl <onitake@gmail.com>");
+MODULE_PARM_DESC(fw_name, "firmware file name including extention to be loaded");
 MODULE_VERSION(DRIVER_VERSION);
 MODULE_LICENSE("GPL");


### PR DESCRIPTION
by loading the module with parameter fw_name=PATH/FIRMWARE.fw
it is possible to load user defined firmware files
especially for generic system setups it will be possible to decide
which firmware to be loaded based on HW constants (e.g. product_name,..)
