### PR TITLE
ACPI API calls on systems that do not support ACPI are implicit decla…

### DIFF
--- a/gslx680_ts_acpi.c
+++ b/gslx680_ts_acpi.c
@@ -472,16 +472,20 @@ static irqreturn_t gsl_ts_irq(int irq, void *arg)
 static void gsl_ts_power(struct i2c_client *client, bool turnoff)
 {
 	struct gsl_ts_data *data = i2c_get_clientdata(client);
+#ifdef CONFIG_ACPI
 	int error;
+#endif
 
 	if (data) {
 		if (data->gpio) {
 			gpiod_set_value_cansleep(data->gpio, turnoff ? 0 : 1);
+#ifdef CONFIG_ACPI
 		} else {
 			error = acpi_bus_set_power(ACPI_HANDLE(&client->dev), turnoff ? ACPI_STATE_D3 : ACPI_STATE_D0);
 			if (error) {
 				dev_warn(&client->dev, "%s: error changing power state: %d\n", __func__, error);
 			}
+#endif
 		}
 		usleep_range(20000, 50000);
 	}
@@ -564,6 +568,7 @@ static int gsl_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 
 	/* Try to use ACPI power methods first */
 	acpipower = false;
+#ifdef CONFIG_ACPI
 	if (ACPI_COMPANION(&client->dev)) {
 		/* Wake the device up with a power on reset */
 		if (acpi_bus_set_power(ACPI_HANDLE(&client->dev), ACPI_STATE_D3)) {
@@ -572,7 +577,7 @@ static int gsl_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 			acpipower = true;
 		}
 	}
-
+#endif
 	/* Not available, use GPIO settings from DSDT/DT instead */
 	if (!acpipower) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)


### PR DESCRIPTION
…rations.

This patch makes sure that ACPI calls are made only when the kernel is compiled
with ACPI.

Signed-off-by: Steven Barker steven.barker@gizmite.com

With this patch this driver works with device tree and can be built in tree on 4.6.0-rc5
