### PR TITLE
fix building on linux 6.3+

### DIFF
--- a/gslx680_ts_acpi.c
+++ b/gslx680_ts_acpi.c
@@ -491,7 +491,11 @@ static void gsl_ts_power(struct i2c_client *client, bool turnoff)
 	}
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 static int gsl_ts_probe(struct i2c_client *client, const struct i2c_device_id *id)
+#else
+static int gsl_ts_probe(struct i2c_client *client)
+#endif
 {
 	struct gsl_ts_data *ts;
 	const struct firmware *fw = NULL;


### PR DESCRIPTION
linux 6.3 included commit 03c835f498b5 ("i2c: Switch .probe() to not take an id parameter")